### PR TITLE
Fix compatibility with current versions of HDT

### DIFF
--- a/DeckPredictor/DeckPredictor.csproj
+++ b/DeckPredictor/DeckPredictor.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DeckPredictor</RootNamespace>
     <AssemblyName>DeckPredictor</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/DeckPredictor/DeckPredictorPlugin.cs
+++ b/DeckPredictor/DeckPredictorPlugin.cs
@@ -198,7 +198,7 @@ namespace DeckPredictor
 
 		public Version Version
 		{
-			get { return new Version(1, 2, 2); }
+			get { return new Version(1, 2, 3); }
 		}
 	}
 }

--- a/DeckPredictorTests/DeckPredictorTests.csproj
+++ b/DeckPredictorTests/DeckPredictorTests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DeckPredictorTests</RootNamespace>
     <AssemblyName>DeckPredictorTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>


### PR DESCRIPTION
This fixes the issue with current versions of HDT and bumps the version number up by 0.0.1

All that needed to happen was just that target .NET framework had to be updated to match the newer version that HDT is currently targeting, but I was not familiar with the development for deck tracker plugins so it took a little bit to figure that out.

Screenshot showing it back in the plugins list again after compiling.
![hdt-deck-predictor](https://user-images.githubusercontent.com/61520249/95821073-1f293780-0cde-11eb-9d8c-e18ae649d60a.png)
