### PR TITLE
Update MetaRetriever to scrape from MetaStats

### DIFF
--- a/DeckPredictor/CardProximityRanker.cs
+++ b/DeckPredictor/CardProximityRanker.cs
@@ -1,6 +1,8 @@
-﻿using HearthMirror;
-using Hearthstone_Deck_Tracker.Hearthstone;
+﻿/*
+using HearthMirror;
 using Hearthstone_Deck_Tracker;
+*/
+using Hearthstone_Deck_Tracker.Hearthstone;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;

--- a/DeckPredictor/DeckPredictor.csproj
+++ b/DeckPredictor/DeckPredictor.csproj
@@ -31,28 +31,45 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AngleSharp, Version=0.14.0.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
+      <HintPath>..\packages\AngleSharp.0.14.0\lib\net472\AngleSharp.dll</HintPath>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+    </Reference>
     <Reference Include="HearthDb, Version=7.1.1.17994, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Hearthstone-Deck-Tracker\Hearthstone Deck Tracker\bin\x86\Debug\HearthDb.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="HearthMirror">
+    <Reference Include="HearthMirror, Version=20.0.0.0, Culture=neutral, processorArchitecture=x86">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Hearthstone-Deck-Tracker\Hearthstone Deck Tracker\bin\x86\Debug\HearthMirror.dll</HintPath>
     </Reference>
     <Reference Include="HearthstoneDeckTracker, Version=1.1.7.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Hearthstone-Deck-Tracker\Hearthstone Deck Tracker\bin\x86\Debug\HearthstoneDeckTracker.exe</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="MahApps.Metro">
       <HintPath>..\..\Hearthstone-Deck-Tracker\Hearthstone Deck Tracker\bin\x86\Debug\MahApps.Metro.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
+    <Reference Include="PresentationCore">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="PresentationFramework">
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encoding.CodePages, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encoding.CodePages.4.5.0\lib\net461\System.Text.Encoding.CodePages.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
@@ -60,13 +77,16 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="WindowsBase" />
+    <Reference Include="WindowsBase">
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutoUpdater.cs" />
     <Compile Include="CardProximityRanker.cs" />
     <Compile Include="CustomLog.cs" />
     <Compile Include="IOpponent.cs" />
+    <Compile Include="MetaRetrieverLegacy.cs" />
     <Compile Include="Opponent.cs" />
     <Compile Include="PredictionInfo.cs" />
     <Compile Include="PredictionController.cs" />
@@ -100,6 +120,10 @@
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Resources\icon_optimal.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/DeckPredictor/MetaRetrieverLegacy.cs
+++ b/DeckPredictor/MetaRetrieverLegacy.cs
@@ -1,0 +1,102 @@
+﻿/*
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Hearthstone_Deck_Tracker;
+using Hearthstone_Deck_Tracker.Hearthstone;
+using HearthDb;
+using HearthDb.Enums;
+
+namespace DeckPredictor
+{
+	class MetaRetrieverLegacy
+	{
+		// How many days we wait before updating the meta since the last download.
+		private const double RecentDownloadTimeoutDays = 1;
+		private const string MetaVersionUrl = "http://metastats.net/metadetector/metaversion.php";
+		private const string MetaFileUrl = "https://s3.amazonaws.com/metadetector/metaDecks.xml.gz";
+		private static readonly string MetaFilePath =
+				Path.Combine(DeckPredictorPlugin.DataDirectory, @"metaDecks.xml");
+		private static readonly string MetaArchivePath = MetaFilePath + ".gz";
+
+		public async Task<List<Deck>> RetrieveMetaDecks(PluginConfig config)
+		{
+			// First check if we need to download the meta file.
+			string newMetaVersion = "";
+			if (!File.Exists(MetaFilePath))
+			{
+				Log.Info("No meta file found.");
+				using (WebClient client = new WebClient())
+				{
+					newMetaVersion = await client.DownloadStringTaskAsync(MetaVersionUrl);
+				}
+			}
+			else
+			{
+				double daysSinceLastDownload = (DateTime.Now - config.CurrentMetaFileDownloadTime).TotalDays;
+				if (daysSinceLastDownload > RecentDownloadTimeoutDays)
+				{
+					Log.Info(daysSinceLastDownload +
+							" days since meta file has been updated, checking for new version.");
+					using (WebClient client = new WebClient())
+					{
+						newMetaVersion = await client.DownloadStringTaskAsync(MetaVersionUrl);
+					}
+					if (newMetaVersion.Trim() != "" && newMetaVersion != config.CurrentMetaFileVersion)
+					{
+						Log.Info("New version detected: " + newMetaVersion +
+								", old version: " + config.CurrentMetaFileVersion);
+					}
+					else
+					{
+						Log.Debug("Newest version of meta file matches cached version: " + newMetaVersion);
+						newMetaVersion = "";
+					}
+				}
+				else
+				{
+					Log.Debug("Cached meta file is only " + daysSinceLastDownload + " days old.");
+				}
+			}
+
+			if (newMetaVersion != "")
+			{
+				Log.Info("Downloading new meta file.");
+				using (WebClient client = new WebClient())
+				{
+					await client.DownloadFileTaskAsync(MetaFileUrl, MetaArchivePath);
+				}
+
+				Log.Info("Meta file downloaded, unzipping...");
+				FileInfo archiveFile = new FileInfo(MetaArchivePath);
+
+				using (FileStream archiveFileStream = archiveFile.OpenRead())
+				{
+					using (FileStream unzippedFileStream = File.Create(MetaFilePath))
+					{
+						using (GZipStream unzipStream =
+								new GZipStream(archiveFileStream, CompressionMode.Decompress))
+						{
+							unzipStream.CopyTo(unzippedFileStream);
+						}
+					}
+				}
+
+				config.CurrentMetaFileVersion = newMetaVersion;
+				config.CurrentMetaFileDownloadTime = DateTime.Now;
+				config.Save();
+			}
+
+			Log.Debug("Loading meta file");
+			List<Deck> metaDecks = XmlManager<List<Deck>>.Load(MetaFilePath);
+			Log.Info("Meta retrieved, " + metaDecks.Count + " decks loaded.");
+			return metaDecks;
+		}
+	}
+}
+*/

--- a/DeckPredictor/PredictionLayout.xaml
+++ b/DeckPredictor/PredictionLayout.xaml
@@ -2,6 +2,7 @@
 		xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 		xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 		xmlns:hdt="clr-namespace:Hearthstone_Deck_Tracker;assembly=HearthstoneDeckTracker"
+        xmlns:utility="clr-namespace:Hearthstone_Deck_Tracker.Utility;assembly=HearthstoneDeckTracker"
 		xmlns:controls="clr-namespace:Hearthstone_Deck_Tracker.Controls;assembly=HearthstoneDeckTracker"
 		Height="Auto" Width="Auto"
 		Background="Transparent">
@@ -10,7 +11,11 @@
 			<StackPanel Orientation="Horizontal"/>
 	   </ItemsPanelTemplate>
 	</ItemsControl.ItemsPanel>
-
+    <ItemsControl.Resources>
+        <ResourceDictionary>
+            <utility:ConfigWrapper x:Key="ConfigWrapper"/>
+        </ResourceDictionary>
+    </ItemsControl.Resources>
 	<StackPanel Orientation="Vertical">
 		<!-- Viewbox used for scaling if card list gets too large -->
 		<Viewbox Name="CardView" Height="Auto">
@@ -77,13 +82,15 @@
 			</StackPanel>
 		</Border>
 	</StackPanel>
-	<!-- Tool Tip appears to the right of the main stack -->
-	<Canvas>
-		<controls:CardToolTipControl
-			x:Name="CardToolTip"
+    <!-- Tool Tip appears to the right of the main stack -->
+    <!--
+    <Canvas Style="{StaticResource ConfigWrapper}">
+        <controls:CardImage
+			x:Name="ToolTipCardBlock"
 			Height="auto"
 			Panel.ZIndex="100"
 			VerticalAlignment="Top"
 		   Visibility="Hidden"/>
-   </Canvas>
+    </Canvas>
+    -->
 </ItemsControl>

--- a/DeckPredictor/PredictionLayout.xaml.cs
+++ b/DeckPredictor/PredictionLayout.xaml.cs
@@ -45,20 +45,20 @@ namespace DeckPredictor
 				var cardIndex = (int)(relativePos.Y / cardSize);
 				if (cardIndex < 0 || cardIndex >= CardList.Items.Count)
 				{
-					CardToolTip.Visibility = Visibility.Collapsed;
+					// ToolTipCardBlock.Visibility = Visibility.Collapsed;
 					return;
 				}
-				CardToolTip.SetValue(
-					DataContextProperty, CardList.Items.Cast<AnimatedCard>().ElementAt(cardIndex).Card);
+				//ToolTipCardBlock.SetValue(
+				//	DataContextProperty, CardList.Items.Cast<AnimatedCard>().ElementAt(cardIndex).Card);
 
 				// Set the top of the tooltip so it appears next to the card.
 				var cardTopPos = cardSize * cardIndex;
-				Canvas.SetTop(CardToolTip, cardTopPos);
-				CardToolTip.Visibility = Visibility.Visible;
+				//Canvas.SetTop(ToolTipCardBlock, cardTopPos);
+				//ToolTipCardBlock.Visibility = Visibility.Visible;
 			}
 			else
 			{
-				CardToolTip.Visibility = Visibility.Collapsed;
+				//ToolTipCardBlock.Visibility = Visibility.Collapsed;
 			}
 		}
 

--- a/DeckPredictor/packages.config
+++ b/DeckPredictor/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AngleSharp" version="0.14.0" targetFramework="net472" />
+  <package id="CopyLocalTrue" version="1.0.2" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net472" />
+  <package id="System.Text.Encoding.CodePages" version="4.5.0" targetFramework="net472" />
+</packages>


### PR DESCRIPTION
This also effectively removes the intermediate XML storage, which means that every time HDT starts up and the plugin is loaded that MetaStats will be scraped.

This change also fixes some minor bugs that prevented the plugin from loading correctly.